### PR TITLE
Refactor watchlist counters to persist data between re-renders

### DIFF
--- a/src/components/WatchlistSidebar/WatchlistSidebar.js
+++ b/src/components/WatchlistSidebar/WatchlistSidebar.js
@@ -5,16 +5,19 @@ import styles from "../WatchlistSidebar/WatchlistSidebar.module.css";
 import { Emoji, MovieListType } from "../../constants/constants";
 import { useStore, useUsernameStore } from "../../store/store";
 import useWatchlistName from "../../hooks/useWatchlistName";
+import useQueryUsername from "../../hooks/useQueryUsername";
 
 export const WatchlistSidebar = () => {
   const cn = classNames.bind(styles);
 
   const updateMovieListType = useStore(state => state.changeMovieListType);
-  const movieCountAddedList = useStore(state => state.movieCountAddedList);
-  const movieCountRemovedList = useStore(state => state.movieCountRemovedList);
   const { username } = useUsernameStore();
 
   const { watchlistNameAdded, watchlistNameRemoved } = useWatchlistName();
+
+  const usernameData = useQueryUsername();
+  const movieCountAddedList = usernameData?.lists?.added?.total || 0;
+  const movieCountRemovedList = usernameData?.lists?.removed?.total || 0;
 
   return (
     <aside className={styles.watchlistContainer}>

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -1,5 +1,8 @@
-export const baseURL = 'https://josie-moviehut.herokuapp.com/api/movies';
-export const baseURL_2 = 'https://josie-moviehut.herokuapp.com/api/movie';
+export const URL = {
+    movies: 'https://josie-moviehut.herokuapp.com/api/movies',
+    movie: 'https://josie-moviehut.herokuapp.com/api/movie',
+    user: 'https://josie-moviehut.herokuapp.com/api/user'
+} as const;
 
 // Types of movie lists available to user
 export enum MovieListType {
@@ -17,6 +20,7 @@ export enum Emoji {
     Eyes = '👀'
 }
 
+// Types of button labels
 export enum ButtonLabel {
     Add = 'ADD',
     Remove = 'REMOVE',

--- a/src/hooks/useQueryList.js
+++ b/src/hooks/useQueryList.js
@@ -10,7 +10,7 @@ export default function useQueryList (movieListConfig) {
     movieListConfig.queryKey,
     ({ pageParam = 1 }) => getAPI(movieListConfig.getUrlFunction(pageParam, username)),
     {
-      getNextPageParam: (lastPage) => (lastPage.pagination.next.page || undefined),
+      getNextPageParam: (lastPage) => lastPage.pagination?.next?.page,
       useErrorBoundary: true,
     }
   );

--- a/src/hooks/useQueryUsername.js
+++ b/src/hooks/useQueryUsername.js
@@ -1,0 +1,16 @@
+import { useQuery } from "react-query";
+
+import { useUsernameStore } from "../store/store";
+import { getAPI } from "../services/utils/helper";
+import { getUsername } from "../services/config";
+
+export default function useQueryUsername () {
+  const { username } = useUsernameStore();
+
+  const { data } = useQuery(
+    'username',
+    () => getAPI(getUsername(username))
+  );
+
+  return data?.data;
+}

--- a/src/pages/MoviesPage/MovieListRecommended/MovieListRecommended.tsx
+++ b/src/pages/MoviesPage/MovieListRecommended/MovieListRecommended.tsx
@@ -11,8 +11,6 @@ import LoadMoreMovies from "../LoadMoreMovies/LoadMoreMovies";
 
 const MovieListRecommended = () => {
     const movieListType = useStore(state => state.movieListType);
-    const setMovieCountAddedList = useStore(state => state.setMovieCountAddedList);
-    const setMovieCountRemovedList = useStore(state => state.setMovieCountRemovedList);
 
     const movieListConfig = getMovieListConfiguration(movieListType);
     const {movies: recommendedMovies, fetchNextPage, hasNextPage} = useQueryList(movieListConfig);
@@ -23,7 +21,6 @@ const MovieListRecommended = () => {
     // Runs when user adds a movie to added watchlist
     const handleMoveToAddedList = (_id: string, event: React.SyntheticEvent<HTMLButtonElement>): void => {
         event.stopPropagation();
-        setMovieCountAddedList();
 
         // Send (not delete) movie from recommended list to added list
         // The function (with variables) to manually to trigger the mutation
@@ -34,7 +31,6 @@ const MovieListRecommended = () => {
     // Runs when user adds a movie to removed watchlist
     const handleMoveToRemovedList = (_id: string, event: React.SyntheticEvent<HTMLButtonElement>): void => {
         event.stopPropagation();
-        setMovieCountRemovedList();
 
         // Send (not delete) movie from recommended list to removed list
         // @ts-ignore

--- a/src/pages/MoviesPage/MovieListRecommended/hooks/useUpdateList.js
+++ b/src/pages/MoviesPage/MovieListRecommended/hooks/useUpdateList.js
@@ -9,6 +9,7 @@ export default function useUpdateList (url) {
   const mutation = useMutation({
     mutationFn: (id) => postAPI(url(id, username)),
     onSuccess: () => {
+      queryClient.invalidateQueries('username');
       // Invalidates every query with a key that starts with `list-recommended`
       // Once invalidated, it auto re-fetches the recommended movie list with updated result
       return queryClient.invalidateQueries('list-recommended');

--- a/src/pages/MoviesPage/MovieListUserAdded/MovieListUserAdded.tsx
+++ b/src/pages/MoviesPage/MovieListUserAdded/MovieListUserAdded.tsx
@@ -1,10 +1,11 @@
 import React from "react";
+import {useStore} from "../../../store/store";
+
+import useQueryList from "../../../hooks/useQueryList";
+import getMovieListConfiguration from "../utils/movieListConfiguration";
 
 import MovieList from "../MovieList/MovieList";
 import LoadMoreMovies from "../LoadMoreMovies/LoadMoreMovies";
-import {useStore} from "../../../store/store";
-import getMovieListConfiguration from "../utils/movieListConfiguration";
-import useQueryList from "../../../hooks/useQueryList";
 
 const MovieListUserAdded = () => {
     const movieListType = useStore(state => state.movieListType);

--- a/src/services/config.js
+++ b/src/services/config.js
@@ -1,4 +1,4 @@
-import { baseURL, baseURL_2 } from "../constants/constants";
+import { URL } from "../constants/constants";
 
 export const getUrlMovieList = (currentPage, numberOfMoviesPerPage, username, listName) => {
   const currentPageParam = `page=${currentPage}`;
@@ -6,7 +6,7 @@ export const getUrlMovieList = (currentPage, numberOfMoviesPerPage, username, li
   const listNameParam = `list=${listName}`;
   const usernameParam = `username=${username}`;
 
-  const url = baseURL + '?' + currentPageParam + '&' + moviePageLimitParam + '&' + listNameParam + '&' + usernameParam;
+  const url = URL.movies + '?' + currentPageParam + '&' + moviePageLimitParam + '&' + listNameParam + '&' + usernameParam;
   return url;
 }
 
@@ -15,6 +15,13 @@ export const postUrlMovieList = (id, username, listName) => {
   const listTypeParam = `list=${listName}`;
   const usernameParam = `username=${username}`;
 
-  const url = baseURL_2 + '?' + movieIdParam + '&' + listTypeParam + '&' + usernameParam;
+  const url = URL.movie + '?' + movieIdParam + '&' + listTypeParam + '&' + usernameParam;
+  return url;
+}
+
+export const getUsername = (username) => {
+  const usernameParam = `username=${username}`;
+
+  const url = URL.user + '?' + usernameParam;
   return url;
 }

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -8,12 +8,6 @@ const username = getFormatToLowercase(getGenerateUsername());
 interface StoreState {
     movieListType: string,
     changeMovieListType: (newMovieListType: string) => void,
-
-    movieCountAddedList: number,
-    setMovieCountAddedList: () => void,
-
-    movieCountRemovedList: number,
-    setMovieCountRemovedList: () => void,
 }
 
 export const useStore = create<StoreState>(
@@ -21,20 +15,9 @@ export const useStore = create<StoreState>(
         movieListType: MovieListType.Recommended,
         changeMovieListType: (newMovieListType) => set(
             {movieListType: newMovieListType}
-        ),
-
-        movieCountAddedList: 0,
-        setMovieCountAddedList: () => set(
-            (state) => ({movieCountAddedList: state.movieCountAddedList + 1})
-        ),
-
-        movieCountRemovedList: 0,
-        setMovieCountRemovedList: () => set(
-            (state) => ({movieCountRemovedList: state.movieCountRemovedList + 1})
         )
     })
 );
-
 
 export const useUsernameStore = create(
     persist(


### PR DESCRIPTION
Every generated username can now see how many movies they have on each list on different browsers and between re-renders.

Watchlist counter will now only update (increment) IF there is a mutation (a movie card is taken from one list and moved to another).

**TL;DR** 
Moved watchlist movie counter (_ex: Addded(_**20**_)_) from client store manager to BE.
<img width="853" alt="Screenshot 2023-01-19 at 19 22 21" src="https://user-images.githubusercontent.com/23569001/213528950-82e531f3-6ce2-441f-932a-c6cbb901af2a.png">

